### PR TITLE
PR #2: Clean and transform data — Mood Index and feature engineering

### DIFF
--- a/notebooks/02_clean_transform.ipynb
+++ b/notebooks/02_clean_transform.ipynb
@@ -1,0 +1,337 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "80dd0233",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Importing libraries\n",
+    "import pandas as pd\n",
+    "import yfinance as yf\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "import shap\n",
+    "import joblib\n",
+    "import os\n",
+    "from statsmodels.tsa.stattools import grangercausalitytests\n",
+    "from sklearn.model_selection import train_test_split\n",
+    "from sklearn.preprocessing import MinMaxScaler\n",
+    "from datetime import datetime\n",
+    "from sklearn.metrics import f1_score, precision_score, recall_score, confusion_matrix, classification_report\n",
+    "from xgboost import XGBClassifier\n",
+    "from sklearn.model_selection import GridSearchCV\n",
+    "from dotenv import load_dotenv\n",
+    "from fredapi import Fred\n",
+    "from pytrends.request import TrendReq"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "264a5b17",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 📅 Set time range\n",
+    "start_date = \"2004-01-01\"\n",
+    "end_date = datetime.today().strftime('%Y-%m-%d')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "b7e9e5f6",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Load .env file\n",
+    "load_dotenv()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "57983c10",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Access my key\n",
+    "fred_api_key = os.getenv(\"FRED_API_KEY\")\n",
+    "fred = Fred(api_key=fred_api_key)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "9649be2b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Now fetch UNRATE\n",
+    "unrate = fred.get_series('UNRATE')\n",
+    "unrate = unrate.to_frame(name='Unemployment')\n",
+    "unrate.index = pd.to_datetime(unrate.index)\n",
+    "unrate = unrate.resample(\"W-FRI\").ffill().reset_index()\n",
+    "unrate.columns = [\"Date\", \"Unemployment\"]\n",
+    "unrate = unrate[unrate[\"Date\"] >= pd.to_datetime(start_date)]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "4ebbff80",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "YF.download() has changed argument auto_adjust default to True\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[*********************100%***********************]  1 of 1 completed\n"
+     ]
+    }
+   ],
+   "source": [
+    "# 📥 Downloading S&P 500 data\n",
+    "sp500 = yf.download(\"^GSPC\", start=start_date, end=end_date, interval='1wk')\n",
+    "sp500.reset_index(inplace=True)\n",
+    "sp500 = sp500[[\"Date\", \"Close\", \"Volume\"]]\n",
+    "sp500[\"Date\"] = pd.to_datetime(sp500[\"Date\"]) + pd.offsets.Week(weekday=4)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "9ce3bfb6",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[*********************100%***********************]  1 of 1 completed\n"
+     ]
+    }
+   ],
+   "source": [
+    "# 📥 Downloading VIX data\n",
+    "vix = yf.download(\"^VIX\", start=start_date, end=end_date, interval='1wk')\n",
+    "vix.reset_index(inplace=True)\n",
+    "vix = vix[[\"Date\", \"Close\"]].rename(columns={\"Close\": \"VIX_Close\"})\n",
+    "vix[\"Date\"] = pd.to_datetime(vix[\"Date\"]) + pd.offsets.Week(weekday=4)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "15713668",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pytrends = TrendReq(hl='en-US', tz=360)\n",
+    "\n",
+    "# Set search term and time frame\n",
+    "kw_list = [\"stock market crash\"]\n",
+    "pytrends.build_payload(kw_list, cat=0, timeframe='2004-01-01 2025-06-20', geo='', gprop='')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "6c8843cd",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "C:\\Users\\melny\\AppData\\Local\\Programs\\Python\\Python310\\lib\\site-packages\\pytrends\\request.py:260: FutureWarning: Downcasting object dtype arrays on .fillna, .ffill, .bfill is deprecated and will change in a future version. Call result.infer_objects(copy=False) instead. To opt-in to the future behavior, set `pd.set_option('future.no_silent_downcasting', True)`\n",
+      "  df = df.fillna(False)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Download interest over time\n",
+    "google_sentiment = pytrends.interest_over_time()\n",
+    "google_sentiment = google_sentiment.reset_index()[[\"date\", \"stock market crash\"]]\n",
+    "google_sentiment.columns = [\"Date\", \"Google_Sentiment_Index\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "8aaa8d67",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Resample to weekly (Friday)\n",
+    "google_sentiment[\"Date\"] = pd.to_datetime(google_sentiment[\"Date\"])\n",
+    "google_sentiment = google_sentiment.set_index(\"Date\").resample(\"W-FRI\").ffill().reset_index()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "62285d35",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "📅 Dataset Date Ranges\n",
+      "------------------------------\n",
+      "S&P 500:          2004-01-02 → 2025-06-13\n",
+      "VIX:              2004-01-02 → 2025-06-13\n",
+      "Unemployment:     2004-01-02 → 2025-05-02\n",
+      "Google Trends:    2004-01-02 → 2025-06-06\n"
+     ]
+    }
+   ],
+   "source": [
+    "#Checking which latest data available\n",
+    "print(\"📅 Dataset Date Ranges\\n\" + \"-\"*30)\n",
+    "\n",
+    "print(f\"S&P 500:          {sp500['Date'].min().date()} → {sp500['Date'].max().date()}\")\n",
+    "print(f\"VIX:              {vix['Date'].min().date()} → {vix['Date'].max().date()}\")\n",
+    "print(f\"Unemployment:     {unrate['Date'].min().date()} → {unrate['Date'].max().date()}\")\n",
+    "print(f\"Google Trends:    {google_sentiment['Date'].min().date()} → {google_sentiment['Date'].max().date()}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "915a01f0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Align all datasets to the latest valid end date: 2025-05-02\n",
+    "latest_date = pd.to_datetime(\"2025-05-02\")\n",
+    "\n",
+    "sp500 = sp500[sp500[\"Date\"] <= latest_date]\n",
+    "vix = vix[vix[\"Date\"] <= latest_date]\n",
+    "unrate = unrate[unrate[\"Date\"] <= latest_date]\n",
+    "google_sentiment = google_sentiment[google_sentiment[\"Date\"] <= latest_date]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "194b37c7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 🔗 Merge all datasets\n",
+    "df = sp500.merge(vix, on=\"Date\", how=\"outer\")\n",
+    "# 🧼 Flatten column levels if merged DataFrame has multi-index columns\n",
+    "if isinstance(df.columns, pd.MultiIndex):\n",
+    "    df.columns = [' '.join(col).strip() for col in df.columns.values]\n",
+    "\n",
+    "df = df.merge(unrate, on=\"Date\", how=\"outer\")\n",
+    "df = df.merge(google_sentiment, on=\"Date\", how=\"left\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "51ac397b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 🧼 Clean and compute features\n",
+    "# Rename columns to standard names\n",
+    "df = df.rename(columns={\n",
+    "    \"Close ^GSPC\": \"Close\",\n",
+    "    \"Volume ^GSPC\": \"Volume\",\n",
+    "    \"VIX_Close ^VIX\": \"VIX_Close\"\n",
+    "})\n",
+    "\n",
+    "df = df.sort_values(\"Date\").reset_index(drop=True)\n",
+    "df = df.dropna(subset=[\"Close\", \"VIX_Close\", \"Unemployment\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "b3e27f06",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Calculate returns and changes\n",
+    "df[\"SP500_Returns\"] = df[\"Close\"].pct_change()\n",
+    "df[\"VIX_Change\"] = df[\"VIX_Close\"].pct_change()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "a1386718",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Define mood index function\n",
+    "def get_mood_index(df, vix_col='VIX_Close', google_col='Google_Sentiment_Index', unemp_col='Unemployment'):\n",
+    "    scaler = MinMaxScaler()\n",
+    "    norm_values = scaler.fit_transform(df[[vix_col, google_col, unemp_col]])\n",
+    "    norm_df = pd.DataFrame(norm_values, columns=[\"VIX_Norm\", \"Google_Norm\", \"Unemp_Norm\"])\n",
+    "    norm_df.index = df.index\n",
+    "    df = df.copy()\n",
+    "    df[[\"VIX_Norm\", \"Google_Norm\", \"Unemp_Norm\"]] = norm_df\n",
+    "    df[\"Mood_Index\"] = df[[\"VIX_Norm\", \"Google_Norm\", \"Unemp_Norm\"]].mean(axis=1)\n",
+    "    df[\"Mood_Zone\"] = df[\"Mood_Index\"].apply(lambda val: \"Calm\" if val < 0.4 else \"Cautious\" if val < 0.7 else \"Panic\")\n",
+    "    return df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "1c435415",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Apply mood index\n",
+    "df = get_mood_index(df)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
### Summary

This pull request introduces the second phase of the project: `02_clean_transform.ipynb`.

Key steps completed:
- ✅ Merged raw datasets (S&P 500, VIX, UNRATE, Google Trends) on a weekly timeline
- ✅ Cleaned column names and dropped rows with missing key values
- ✅ Engineered first-level features: `SP500_Returns`, `VIX_Change`
- ✅ Created and applied a custom `Mood Index` using MinMax scaling of behavioral & economic indicators
- ✅ Classified weekly market mood into: Calm, Cautious, or Panic zones

### Notebook Added

- `notebooks/02_clean_transform.ipynb`

### Next Step

PR #3 will focus on exploratory data analysis (EDA), plotting market moods vs. events like 2008 and COVID, and exploring relationships visually.