### PR TITLE
Hotfix PR #2.1: Rename data_cleaning.py to mood_features.py and modularize Mood Index usage

### DIFF
--- a/notebooks/02_clean_data.ipynb
+++ b/notebooks/02_clean_data.ipynb
@@ -1,21 +1,43 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "id": "45eb8857",
+   "metadata": {},
+   "source": [
+    "02_clean_data"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "a1b4ee0e",
+   "id": "3b45e6ab",
    "metadata": {},
    "outputs": [],
    "source": [
     "# Importing libraries\n",
     "import pandas as pd\n",
-    "from sklearn.preprocessing import MinMaxScaler\n",
-    "import matplotlib.pyplot as plt"
+    "import matplotlib.pyplot as plt\n",
+    "from sklearn.preprocessing import MinMaxScaler"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 2,
+   "id": "1551e5e4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ✅ Import mood index feature from utils\n",
+    "import sys\n",
+    "from pathlib import Path\n",
+    "sys.path.append(str(Path().resolve().parent))\n",
+    "from utils.mood_features import get_mood_index"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
    "id": "76ee0686",
    "metadata": {},
    "outputs": [],
@@ -29,13 +51,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "id": "e80202ff",
    "metadata": {},
    "outputs": [],
    "source": [
     "# 🔗 Merge all datasets\n",
-    "df = sp500.merge(vix, on=\"Date\", how=\"outer\")\n",
+    "df = sp500.merge(vix, on=\"Date\", how=\"outer\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "f797825f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# 🧼 Flatten column levels if merged DataFrame has multi-index columns\n",
     "if isinstance(df.columns, pd.MultiIndex):\n",
     "    df.columns = [' '.join(col).strip() for col in df.columns.values]\n",
@@ -46,7 +77,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 6,
    "id": "7ff5e06c",
    "metadata": {},
    "outputs": [],
@@ -65,7 +96,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 7,
    "id": "8c05f4ab",
    "metadata": {},
    "outputs": [],
@@ -77,7 +108,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 8,
    "id": "9788c028",
    "metadata": {},
    "outputs": [],
@@ -89,38 +120,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 9,
    "id": "c3f8a52c",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Define mood index function\n",
-    "def get_mood_index(df, vix_col='VIX_Close', google_col='Google_Sentiment_Index', unemp_col='Unemployment'):\n",
-    "    scaler = MinMaxScaler()\n",
-    "    norm_values = scaler.fit_transform(df[[vix_col, google_col, unemp_col]])\n",
-    "    norm_df = pd.DataFrame(norm_values, columns=[\"VIX_Norm\", \"Google_Norm\", \"Unemp_Norm\"])\n",
-    "    norm_df.index = df.index\n",
-    "    df = df.copy()\n",
-    "    df[[\"VIX_Norm\", \"Google_Norm\", \"Unemp_Norm\"]] = norm_df\n",
-    "    df[\"Mood_Index\"] = df[[\"VIX_Norm\", \"Google_Norm\", \"Unemp_Norm\"]].mean(axis=1)\n",
-    "    df[\"Mood_Zone\"] = df[\"Mood_Index\"].apply(lambda val: \"Calm\" if val < 0.4 else \"Cautious\" if val < 0.7 else \"Panic\")\n",
-    "    return df"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "id": "5fabb7d6",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Apply mood index\n",
+    "# ✅ Apply mood index from utils\n",
     "df = get_mood_index(df)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "d6966c1d",
    "metadata": {},
    "outputs": [],

--- a/utils/mood_features.py
+++ b/utils/mood_features.py
@@ -1,3 +1,9 @@
+"""
+This module was originally created in PR #2 and contains feature engineering logic
+for computing the Mood Index based on VIX, Google Sentiment, and Unemployment data.
+Renamed from 'data_cleaning.py' to 'mood_features.py' in Hotfix PR #2.1 for clarity.
+"""
+
 from sklearn.preprocessing import MinMaxScaler
 import pandas as pd
 


### PR DESCRIPTION
### Summary

This hotfix improves the structure and modularity of code introduced in PR #2 (`02_clean_data.ipynb`) by:

- Renaming `utils/data_cleaning.py` ➜ `utils/mood_features.py`
- Replacing the inline `get_mood_index()` function with a reusable utility import
- Adding docstring to clarify historical context and purpose

### Why This Matters

While the function was originally placed in a file called `data_cleaning.py`, its actual purpose is domain-specific feature engineering. This hotfix corrects the classification, improves notebook readability, and prevents code duplication — while maintaining reproducibility for all prior PRs.

### Changes

- ✅ `get_mood_index()` is now imported from `utils/mood_features.py`
- ✅ `02_clean_data.ipynb` logic remains unchanged in outcome, but is now cleaner
- ✅ Historical continuity is maintained with an explanatory docstring

### Next Steps

- PR #5 (`feature/modeling`) will use `get_mood_index()` via this same module
- No retroactive edits will be required